### PR TITLE
chore: update travis branch name to ci convention

### DIFF
--- a/scripts/travis-update-snapshot
+++ b/scripts/travis-update-snapshot
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SNAPSHOT_DIRECTORY=test/integration/__image_snapshots__
-BRANCH_PREFIX=travis-update-snapshot
+BRANCH_PREFIX=update-snapshot
 
 # Exit early if there are no changes in the snapshot directory
 if [[ -z $(git status $SNAPSHOT_DIRECTORY -s) ]]  ; then
@@ -26,7 +26,7 @@ fi
 # Save state (restored at the end of the script)
 git stash -u
 
-SNAPSHOT_BRANCH="$BRANCH_PREFIX-$TRAVIS_JOB_NUMBER/$CURRENT_BRANCH"
+SNAPSHOT_BRANCH="$BRANCH_PREFIX/travis-$TRAVIS_JOB_NUMBER/$CURRENT_BRANCH"
 
 # Create branch
 git checkout -b $SNAPSHOT_BRANCH


### PR DESCRIPTION
All snapshot branches created from ci jobs should be prefixed
by update-snapshot this makes the branches easily distinguishable
from ordanary branches