### PR TITLE
fix: remove the root parameter option for the workspace node

### DIFF
--- a/packages/shared/tree.js
+++ b/packages/shared/tree.js
@@ -10,8 +10,6 @@ export function findAllApps(root) {
     } else {
       if (node.children) {
         nodes.push(...node.children);
-      } else if (node.root) {
-        nodes.push(...node.root);
       }
     }
   }

--- a/packages/workflow-core/readme.md
+++ b/packages/workflow-core/readme.md
@@ -44,7 +44,7 @@ we would add a layout file for this purpose:
 const workspace : WorkspaceConfig = {
   name: 'advisor:unit-test',
   args: 'file',
-  root: SplitV({
+  children: [SplitV({
     percent: 1.0,
     children: [
       SplitH({
@@ -74,7 +74,7 @@ const workspace : WorkspaceConfig = {
         open: ({ cwd, cmd, args }) => `cd ${cwd} && xterm -T '${cmd} ${args.join(' ')}' -e '${cmd} ${args.join(' ')}'`,
       }),
     ],
-  }),
+  })],
 };
 ```
 

--- a/packages/workflow-core/src/transformer.js
+++ b/packages/workflow-core/src/transformer.js
@@ -7,17 +7,12 @@ export async function apply(node, transformer, args, parent = undefined) {
     children.push(await apply(child, transformer, args, node));
   }
 
-  let root = undefined;
-  if (node.root) {
-    root = await apply(node.root, transformer, args, node);
-  }
-
   transformed = (await transformer.transformAfter(
-    { ...transformed, children, root },
+    { ...transformed, children },
     { args, parent }
-  )) || { ...transformed, children, root };
+  )) || { ...transformed, children };
 
-  return { ...transformed, children, root };
+  return { ...transformed, children };
 }
 
 export async function transform(transforms, config, { args }) {

--- a/packages/workflow-layout/src/index.js
+++ b/packages/workflow-layout/src/index.js
@@ -7,13 +7,10 @@ module.exports = class WorkflowLayout {
 };
 
 function calculateWorkspace(workspace, { position, screen }) {
-  const children = workspace.root ? [workspace.root] : workspace.children;
-
   return {
     ...workspace,
     position,
-    children: workspace.children && children.map(child => calculate(child, { position, screen })),
-    root: workspace.root && children.map(child => calculate(child, { position, screen })),
+    children: workspace.children.map(child => calculate(child, { position, screen })),
   };
 }
 

--- a/packages/workflow-react/src/components/App.js
+++ b/packages/workflow-react/src/components/App.js
@@ -1,34 +1,11 @@
-import { omit } from 'lodash';
-
 export default class App {
 
-  static defaultProps = {
-    percent: 1,
-  }
-
   constructor(props) {
-    this.props = props;
+    this.props = {...props, type: "app"};
     this.children = [];
   }
 
   appendChild(child) {
     this.children.push(child);
-  }
-
-  renderChildren() {
-    this.children.forEach(child => child.render());
-  }
-
-  tree() {
-    const { props, children } = this;
-    return {
-      type: "app",
-      ...omit(props, 'children'),
-      children: children.map(child => child.tree())
-    };
-  }
-
-  render() {
-    this.renderChildren();
   }
 }

--- a/packages/workflow-react/src/components/Layout.js
+++ b/packages/workflow-react/src/components/Layout.js
@@ -1,39 +1,11 @@
-import { omit } from 'lodash';
-
 export default class Layout {
 
-  static defaultProps = {
-    percent: 1,
-  }
-
   constructor(props) {
-    this.props = props;
+    this.props = {...props, type: "layout"};
     this.children = [];
   }
 
   appendChild(child) {
     this.children.push(child);
   }
-
-  renderChildren() {
-    this.children.forEach(child => child.render());
-  }
-
-  tree() {
-    const { props, children } = this;
-
-    return {
-      type: "layout", 
-      ...omit(props, 'children'),
-      children: children.map(child => child.tree()),
-    };
-  }
-
-  render() {
-    this.renderChildren();
-  }
 }
-
-Layout.defaultProps = {
-  percent: 1,
-};

--- a/packages/workflow-react/src/components/Workspace.js
+++ b/packages/workflow-react/src/components/Workspace.js
@@ -1,32 +1,12 @@
-import { omit } from 'lodash';
-
 export default class Workspace {
 
   constructor(props) {
-    this.props = props;
+    this.props = {...props, type: "workspace"};
     this.children = [];
   }
 
   appendChild(child) {
     this.children.push(child);
   }
-
-  renderChildren() {
-    this.children.forEach(child => child.render());
-  }
-
-  tree() {
-    const { props, children } = this;
-
-    return {
-      ...omit(props, 'children'),
-      type: "workspace",
-      root: children[0].tree(),
-    };
-  }
-
-  render() {
-    this.renderChildren();
-  }
-
 }
+

--- a/packages/workflow-react/src/parse/index.js
+++ b/packages/workflow-react/src/parse/index.js
@@ -4,28 +4,20 @@ import {Root, Workspace, App, Layout} from "../components/index";
 const parse = (component) => {
   const {children, props} = component;
 
+  if (!(component instanceof Root)
+      && !(component instanceof Workspace)
+      && !(component instanceof App)
+      && !(component instanceof Layout)) {
+    throw new Error("Component unknown: ", JSON.stringify(component));
+  }
+
   if (component instanceof Root) {
     return { ...parse(children[0]) };
-  } else if (component instanceof Workspace) {
-    return {
-      type: "workspace",
-      ...omit(props, "children"),
-      root: parse(children[0])
-    };
-  } else if (component instanceof App) {
-    return {
-      type: "app",
-      ...omit(props, "children"),
-      children: children.map(parse)
-    };
-  } else if (component instanceof Layout) {
-    return {
-      type: "layout",
-      ...omit(props, "children"),
-      children: children.map(parse)
-    };
   } else {
-    throw new Error("Component unknown: ", JSON.stringify(component));
+    return {
+      ...omit(props, "children"),
+      children: children.map(parse)
+    };
   }
 };
 

--- a/packages/workflow-template/flows/Example.js
+++ b/packages/workflow-template/flows/Example.js
@@ -4,7 +4,7 @@ import {Browser, TextEditor} from "workflow-apps-defaults";
 export default {
   name: 'workflow-example',
   type: 'workspace',
-  root: {
+  children: [{
     type: "layout",
     layout: 'splith',
     percent: 1.0,
@@ -12,5 +12,5 @@ export default {
       { ...Browser, url: 'http://github.com/havardh/workflow/tree/master/packages/workflow-cmd', percent: 0.5 },
       { ...TextEditor, file: __filename, percent: 0.5 },
     ],
-  },
+  }],
 };

--- a/packages/workflow-web/src/flows/WorkflowDevCore.js
+++ b/packages/workflow-web/src/flows/WorkflowDevCore.js
@@ -3,7 +3,7 @@ import {TextEditor, Terminal} from "workflow-apps-defaults";
 export default {
   name: 'workflow-dev-core',
   type: 'workspace',
-  root: {
+  children: [{
     type: "layout",
     layout: 'splitv',
     percent: 1.0,
@@ -11,5 +11,5 @@ export default {
       { ...TextEditor, file: "/home/user/dev/workflow/index.js", percent: 0.66 },
       { ...Terminal, cwd: "/home/user/dev/workflow", percent: 0.34 },
     ],
-  },
+  }],
 };

--- a/packages/workflow-wm-i3/src/index.js
+++ b/packages/workflow-wm-i3/src/index.js
@@ -16,11 +16,9 @@ class I3 {
 
     this.clearWorkspace();
 
-    await this.createLayout(config.root);
+    await this.createLayout(config.children[0]);
 
-    (config.root.length ? config.root : [config.root]).forEach(root =>
-      this.findApps(root).forEach(app => this.open(app))
-    );
+    config.children.forEach(root => this.findApps(root).forEach(app => this.open(app)));
   }
 
   async screen() {


### PR DESCRIPTION
Replaces the root node in all workspace nodes with the standard childrens array.