### PR TITLE
docs: added code-of-conduct contributions guide

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at havardwhoiby@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/contributions.md
+++ b/contributions.md
@@ -1,0 +1,68 @@
+# Contributing
+
+Thanks for showing an interest in contributing to workflow!
+
+**Working on your first Pull Request?** You can learn how from this _free_
+series [How to Contribute to an Open Source Project on GitHub][egghead] by
+Kent C. Dodds.
+
+By making a contribution to this project you agree to abide by the 
+[Code of Conduct][code-of-conduct].
+
+## Project setup
+
+This project uses the [workspaces][yarn-workspaces] feature of the `yarn` 
+package manager. 
+
+1.  Fork and clone the repo
+2.  `yarn` - set up dependencies and link modules
+3.  `yarn build` - builds modules into dist folders
+3.  `git checkout -b <branch>` Create a branch for your PR 
+
+Most of the packages have an example under the `flows` folder which can be
+executed with `yarn example` inside the package folder. Some of these example 
+only run on specific platforms.
+
+### Tests and static analysis
+
+- `yarn eslint` - ESLint. Please fix any errors/warnings :)
+- `yarn format` - Prettier js to autoformat all code.
+- `yarn flow` - Some files are covered by [flowtype][flowtype]
+- `yarn test unit` - Runs the unit tests
+- `yarn test integration` - Runs platform dependent integration tests
+
+#### Continuous integration
+
+There are four ci jobs for the workflow project. These are the unit test suite
+which is executed on Circle CI and the platform dependent integration tests executed
+on Circle ci (linux-i3), travis ci (osx) and appveyor (windows). 
+
+Each of the integration tests runs a given flow and takes a screenshot of the result.
+This screenshot is compared with commited version for an exact match. When the tests
+fails the ci jobs will store the results as artifacts. As these images are hard to 
+generate locally for windows and osx, the travis and appveyor jobs are set up to 
+push a branch with the updated images, for the case where the changes are expected. 
+The linux versions can be reproduced locally with the docker image. 
+
+## Conventions
+
+The [angular commit guide][angular-commit] line is used to govern commit messages. 
+
+## Help needed
+
+Please checkout the [the open issues][issues]
+
+Also, please watch the repo and respond to questions/bug reports/feature
+requests! Thanks!
+
+## Attribution
+
+This guide is adapted from the [Downshift][downshift] contributors guide.
+
+[egghead]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[issues]: https://github.com/havardh/workflow/issues
+[downshift]: https://github.com/paypal/downshift
+[yarn-workspaces]: https://yarnpkg.com/lang/en/docs/workspaces/
+[flowtype]: https://flow.org/
+[angular-commit]: https://gist.github.com/stephenparish/9941e89d80e2bc58a153
+[code-of-conduct]: code-of-conduct.md


### PR DESCRIPTION
The Code of Conduct is copied fromthe Contributors Covenant
and will help to build a welcoming environment.

The Cotributions guide is added in effort to make the codebase
more approachable for contributions.