### PR TITLE
Delete duplicate readme

### DIFF
--- a/packages/workflow-core/Readme.md
+++ b/packages/workflow-core/Readme.md
@@ -1,3 +1,0 @@
-# workflow-core
-
-The core module of workflow. 


### PR DESCRIPTION
There is both `packages/workflow-core/Readme.md` and `packages/workflow-core/readme.md`.
On macos which this gets a little messy because of case insentivity, so
on fresh clone from master I get a diff on the readme file. I deleted
the one that was almost empty.