### PR TITLE
fix(workflow-app-vim): Add empty string as default value for filename

### DIFF
--- a/packages/workflow-app-vim/src/index.js
+++ b/packages/workflow-app-vim/src/index.js
@@ -8,7 +8,7 @@ const vim = {
       throw new Error('Context is not supported');
     }
 
-    return `vim ${file}`;
+    return `vim ${file || ''}`;
   },
 };
 


### PR DESCRIPTION
This will fix the issue where vim will open a new file called undefined
if the filename is specified.

Fixes #109