### PR TITLE
fix(workflow-apps-defaults): make apps default read from appropriate …

### DIFF
--- a/packages/workflow-apps-defaults/index.js
+++ b/packages/workflow-apps-defaults/index.js
@@ -1,67 +1,12 @@
 /* eslint-env node */
-/* eslint-disable no-console */
+/* eslint-disable global-require */
 
-const os = require('os');
-
-const defaultApps = ['Terminal', 'Browser', 'TextEditor'];
-
-let defaults = {};
-
-if (process.browser) {
-  defaults = require('workflow-apps-html').defaults;
-} else {
-  const platformDefaults = (() => {
-    switch (process.platform) {
-      case 'darwin':
-        return {
-          Terminal: require('workflow-app-iterm'),
-          Browser: require('workflow-app-safari'),
-          TextEditor: require('workflow-app-atom'),
-        };
-      case 'win32':
-        return {
-          Terminal: require('workflow-app-powershell'),
-          Browser: require('workflow-app-chrome'),
-          TextEditor: require('workflow-app-notepad'),
-        };
-      case 'linux':
-        return {
-          Terminal: require('workflow-app-xterm'),
-          Browser: require('workflow-app-chrome'),
-          TextEditor: require('workflow-app-atom'),
-        };
-      default:
-        console.log(`Platform '${process.platform}' not supported`);
-        console.log(
-          'Look for an issue for your platform here: https://github.com/havardh/workflow/issues'
-        );
-        process.exit(0);
-        break;
-    }
-    throw new Error('not reachable');
-  })();
-
-  const userDefaults = (() => {
-    try {
-      const defaultModule = require(`${os.homedir()}/.workflow/apps/defaults`);
-
-      return defaultModule.default || defaultModule;
-    } catch (error) {
-      if (error.code !== 'MODULE_NOT_FOUND') {
-        throw error;
-      } else {
-        return {};
-      }
-    }
-  })();
-
-  defaultApps.forEach(app => {
-    defaults[app] = userDefaults[app] || platformDefaults[app];
-  });
+try {
+  module.exports = require('./dist');
+} catch (error) {
+  if (error.code === 'MODULE_NOT_FOUND') {
+    module.exports = require('./src/index');
+  } else {
+    throw error;
+  }
 }
-
-module.exports = {
-  Browser: defaults.Browser,
-  TextEditor: defaults.TextEditor,
-  Terminal: defaults.Terminal,
-};

--- a/packages/workflow-apps-defaults/package.json
+++ b/packages/workflow-apps-defaults/package.json
@@ -10,6 +10,10 @@
     "apps",
     "workflow"
   ],
+  "files": [
+    "dist",
+    "index.js"
+  ],
   "scripts": {
     "example": "node cli.js Example.js"
   },

--- a/packages/workflow-apps-defaults/src/index.js
+++ b/packages/workflow-apps-defaults/src/index.js
@@ -47,9 +47,6 @@ if (process.browser) {
       const path = join(baseFolder, 'apps', 'defaults');
       const defaultModule = require(path);
 
-      console.log(path);
-      process.exit(1);
-
       return defaultModule.default || defaultModule;
     } catch (error) {
       if (error.code !== 'MODULE_NOT_FOUND') {

--- a/packages/workflow-apps-defaults/src/index.js
+++ b/packages/workflow-apps-defaults/src/index.js
@@ -1,0 +1,72 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
+import { baseFolder } from 'shared/env';
+import { join } from 'path';
+
+const defaultApps = ['Terminal', 'Browser', 'TextEditor'];
+
+let defaults = {};
+
+if (process.browser) {
+  defaults = require('workflow-apps-html').defaults;
+} else {
+  const platformDefaults = (() => {
+    switch (process.platform) {
+      case 'darwin':
+        return {
+          Terminal: require('workflow-app-iterm'),
+          Browser: require('workflow-app-safari'),
+          TextEditor: require('workflow-app-atom'),
+        };
+      case 'win32':
+        return {
+          Terminal: require('workflow-app-powershell'),
+          Browser: require('workflow-app-chrome'),
+          TextEditor: require('workflow-app-notepad'),
+        };
+      case 'linux':
+        return {
+          Terminal: require('workflow-app-xterm'),
+          Browser: require('workflow-app-chrome'),
+          TextEditor: require('workflow-app-atom'),
+        };
+      default:
+        console.log(`Platform '${process.platform}' not supported`);
+        console.log(
+          'Look for an issue for your platform here: https://github.com/havardh/workflow/issues'
+        );
+        process.exit(0);
+        break;
+    }
+    throw new Error('not reachable');
+  })();
+
+  const userDefaults = (() => {
+    try {
+      const path = join(baseFolder, 'apps', 'defaults');
+      const defaultModule = require(path);
+
+      console.log(path);
+      process.exit(1);
+
+      return defaultModule.default || defaultModule;
+    } catch (error) {
+      if (error.code !== 'MODULE_NOT_FOUND') {
+        throw error;
+      } else {
+        return {};
+      }
+    }
+  })();
+
+  defaultApps.forEach(app => {
+    defaults[app] = userDefaults[app] || platformDefaults[app];
+  });
+}
+
+module.exports = {
+  Browser: defaults.Browser,
+  TextEditor: defaults.TextEditor,
+  Terminal: defaults.Terminal,
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,13 +9,7 @@ import { resolve, join } from 'path';
 
 import flatMap from 'lodash.flatmap';
 
-const blackList = [
-  'workflow-apps-defaults',
-  'workflow-layout',
-  'workflow-layouts',
-  'workflow-template',
-  'workflow-web',
-];
+const blackList = ['workflow-layout', 'workflow-layouts', 'workflow-template', 'workflow-web'];
 
 const nodeInternalDependencies = {
   'create-workflow-app': ['path', 'util', 'os', 'child_process'],


### PR DESCRIPTION
…home

Makes workflow-apps-defaults depend on the shared/env approach to finding the
workflow-home directory. This ensures that the apps are found when the
WORKFLOW_HOME enviroment variable is set, but also that refactorings of
shared/env will be reflected in the workflow-apps-defaults package.