### PR TITLE
Add workflow-transformer-async

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,15 @@
 {
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parser": "babel-eslint",
   "globals": {
-    Promise: true
-  }
+    "Promise": true
+  },
+  "overrides": [
+    {
+      "files": ["*_tests.js"],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
 }

--- a/packages/workflow-core/src/transformer.js
+++ b/packages/workflow-core/src/transformer.js
@@ -1,5 +1,9 @@
 export async function apply(node, transformer, args, parent = undefined) {
-  let transformed = (await transformer.transformBefore(node, { args, parent })) || node;
+  let transformed = node;
+
+  if (typeof transformer.transformBefore === 'function') {
+    transformed = (await transformer.transformBefore(node, { args, parent })) || node;
+  }
 
   let children = undefined;
   for (const child of node.children || []) {
@@ -7,10 +11,12 @@ export async function apply(node, transformer, args, parent = undefined) {
     children.push(await apply(child, transformer, args, node));
   }
 
-  transformed = (await transformer.transformAfter(
-    { ...transformed, children },
-    { args, parent }
-  )) || { ...transformed, children };
+  if (typeof transformer.transformAfter === 'function') {
+    transformed = (await transformer.transformAfter(
+      { ...transformed, children },
+      { args, parent }
+    )) || { ...transformed, children };
+  }
 
   return { ...transformed, children };
 }

--- a/packages/workflow-react/Readme.md
+++ b/packages/workflow-react/Readme.md
@@ -26,7 +26,7 @@ export default render(
 The `workflow-react` package exports four distinct concepts.
 
  - The `render` function
- - `Components` - `Workspace`, `Layout`, `App`
+ - `Components` - `Workspace`, `Layout`, `App`, `Async`
  - The `createComponent` `Component` factory function
  - The `requireComponent` utility function
 
@@ -201,6 +201,37 @@ export default render(
 Usage
 ```
 workflow <name of flow file> /path/to/file
+```
+
+### Async
+
+The `Async` component is used to load a node as asynchronous. This means that
+the internals of the node can be loaded async. Using the `Async` requires that
+the [`workflow-transformer-async`](../workflow-transformer-async) is used. 
+
+Definition
+```
+<Async
+  loader={async function which returns a node}
+/>
+```
+
+Example
+```
+import React from 'react';
+import render, { Workspace, App } from 'workflow-react';
+
+async function defaultApp() {
+  // returns a default app node async
+}
+
+export default render(
+  <Workspace name={'editor'} >
+    <Async
+      loader={async (props) => ({ ...await defaultApp(), ...props})}
+    >
+  </Workspace>,
+);
 ```
 
 ## The `createComponent` function

--- a/packages/workflow-react/src/components.js
+++ b/packages/workflow-react/src/components.js
@@ -1,3 +1,4 @@
 export const App = 'APP';
 export const Layout = 'LAYOUT';
 export const Workspace = 'WORKSPACE';
+export const Async = 'ASYNC';

--- a/packages/workflow-react/src/components/Async.js
+++ b/packages/workflow-react/src/components/Async.js
@@ -1,0 +1,10 @@
+export default class Async {
+  constructor(props) {
+    this.props = { ...props, type: 'async' };
+    this.children = [];
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+  }
+}

--- a/packages/workflow-react/src/components/index.js
+++ b/packages/workflow-react/src/components/index.js
@@ -1,6 +1,7 @@
 import Root from './Root';
 import Workspace from './Workspace';
 import App from './App';
+import Async from './Async';
 import Layout from './Layout';
 
-export { Root, Workspace, App, Layout };
+export { Root, Workspace, App, Layout, Async };

--- a/packages/workflow-react/src/createComponent.js
+++ b/packages/workflow-react/src/createComponent.js
@@ -71,3 +71,16 @@ export function createComponent(node) {
     throw new Error(`Could not create component for node '${JSON.stringify(node)}'`);
   }
 }
+
+export function createComponentRecursive(module) {
+  if (module.type) {
+    return createComponent(module);
+  } else {
+    return Object.assign(
+      {},
+      ...Object.keys(module).map(k => ({
+        [k]: createComponentRecursive(module[k]),
+      }))
+    );
+  }
+}

--- a/packages/workflow-react/src/createComponent.js
+++ b/packages/workflow-react/src/createComponent.js
@@ -1,6 +1,6 @@
 // @Flow
 import * as React from 'react';
-import { Workspace, App, Layout } from './components';
+import { Workspace, App, Layout, Async } from './components';
 
 export function createAppComponent(app) {
   const { xClass, name } = app;
@@ -47,13 +47,26 @@ export function createWorkspaceComponent(workspace) {
   };
 }
 
-export default function createComponent(node) {
+export function createAsyncComponent(node) {
+  const { xClass, name } = node;
+  return class extends React.Component {
+    static displayName = `async-${xClass || name}`;
+
+    render() {
+      return <Async {...node} {...this.props} />;
+    }
+  };
+}
+
+export function createComponent(node) {
   if (node.type === 'app') {
     return createAppComponent(node);
   } else if (node.type === 'layout') {
     return createLayoutComponent(node);
   } else if (node.type === 'workspace') {
     return createWorkspaceComponent(node);
+  } else if (node.type === 'async') {
+    return createAsyncComponent(node);
   } else {
     throw new Error(`Could not create component for node '${JSON.stringify(node)}'`);
   }

--- a/packages/workflow-react/src/index.js
+++ b/packages/workflow-react/src/index.js
@@ -1,17 +1,9 @@
 import render from './render/index';
 
 import { App, Layout, Workspace, Async } from './components';
-import { createComponent, createComponentRecursive } from './createComponent';
+import { createComponent } from './createComponent';
 import requireComponent from './requireComponent';
 
 export default render;
 
-export {
-  App,
-  Layout,
-  Workspace,
-  Async,
-  createComponent,
-  createComponentRecursive,
-  requireComponent,
-};
+export { App, Layout, Workspace, Async, createComponent, requireComponent };

--- a/packages/workflow-react/src/index.js
+++ b/packages/workflow-react/src/index.js
@@ -1,7 +1,7 @@
 import render from './render/index';
 
 import { App, Layout, Workspace, Async } from './components';
-import { createComponent } from './createComponent';
+import { createComponent, createComponentRecursive } from './createComponent';
 import requireComponent from './requireComponent';
 
 export default render;
@@ -12,5 +12,6 @@ export {
   Workspace,
   Async,
   createComponent,
+  createComponentRecursive,
   requireComponent,
 };

--- a/packages/workflow-react/src/index.js
+++ b/packages/workflow-react/src/index.js
@@ -1,9 +1,16 @@
 import render from './render/index';
 
-import { App, Layout, Workspace } from './components';
-import createComponent from './createComponent';
+import { App, Layout, Workspace, Async } from './components';
+import { createComponent } from './createComponent';
 import requireComponent from './requireComponent';
 
 export default render;
 
-export { App, Layout, Workspace, createComponent, requireComponent };
+export {
+  App,
+  Layout,
+  Workspace,
+  Async,
+  createComponent,
+  requireComponent,
+};

--- a/packages/workflow-react/src/parse/index.js
+++ b/packages/workflow-react/src/parse/index.js
@@ -1,5 +1,5 @@
 import { omit } from 'lodash';
-import { Root, Workspace, App, Layout } from '../components/index';
+import { Root, Workspace, App, Layout, Async } from '../components/index';
 
 const parse = component => {
   const { children, props } = component;
@@ -8,6 +8,7 @@ const parse = component => {
     !(component instanceof Root) &&
     !(component instanceof Workspace) &&
     !(component instanceof App) &&
+    !(component instanceof Async) &&
     !(component instanceof Layout)
   ) {
     throw new Error('Component unknown: ', JSON.stringify(component));

--- a/packages/workflow-react/src/requireComponent.js
+++ b/packages/workflow-react/src/requireComponent.js
@@ -1,18 +1,5 @@
 /* eslint-env node */
-import createComponent from './createComponent';
-
-function createComponentRecursive(module) {
-  if (module.type) {
-    return createComponent(module);
-  } else {
-    return Object.assign(
-      {},
-      ...Object.keys(module).map(k => ({
-        [k]: createComponentRecursive(module[k]),
-      }))
-    );
-  }
-}
+import { createComponentRecursive } from './createComponent';
 
 export default function requireComponent(path) {
   const module = require(path);

--- a/packages/workflow-react/src/utils/createElement.js
+++ b/packages/workflow-react/src/utils/createElement.js
@@ -1,4 +1,4 @@
-import { Root, Workspace, Layout, App } from '../components/index';
+import { Root, Workspace, Layout, App, Async } from '../components/index';
 
 import { ROOT_NODE } from '../render/index';
 
@@ -12,6 +12,7 @@ export function createElement(type, props) {
     WORKSPACE: () => new Workspace(props),
     LAYOUT: () => new Layout(props),
     APP: () => new App(props),
+    ASYNC: () => new Async(props),
     default: undefined,
   };
 

--- a/packages/workflow-transformer-apply-arguments-to-fields/src/index.js
+++ b/packages/workflow-transformer-apply-arguments-to-fields/src/index.js
@@ -10,13 +10,14 @@ function parseValue(value, args) {
 }
 
 export default class WorkflowTransformerApplyArgumentsToFields {
-  async transformBefore() {}
   async transformAfter(node, { args }) {
     switch (node.type) {
       case 'app': {
         const { open, ...rest } = node;
         return { open, ...mapValues(rest, v => parseValue(v, args)) };
       }
+      default:
+        return node;
     }
   }
 }

--- a/packages/workflow-transformer-async/Readme.md
+++ b/packages/workflow-transformer-async/Readme.md
@@ -16,3 +16,17 @@ export default {
   ...
 };
 ```
+
+## Usage
+
+```
+import defaultBrowser from "default-browser"
+
+export const DefaultBrowser = {
+  type: "async",
+  loader: async () => {
+    const browserName = (await defaultBrowser()).name.toLowerCase();
+    return require("workflow-app-" + browserName)
+  }
+}
+```

--- a/packages/workflow-transformer-async/Readme.md
+++ b/packages/workflow-transformer-async/Readme.md
@@ -1,0 +1,18 @@
+# workflow-transformer-async
+
+## Installation
+
+```
+npm install workflow-transformer-async
+```
+
+Add the plugin to your `~/.workflow/config.js` file.
+
+```
+import WorkflowTranformerAsync from "workflow-transformer-async";
+
+export default {
+  transformers: [new WorkflowTranformerAsync()]
+  ...
+};
+```

--- a/packages/workflow-transformer-async/Readme.md
+++ b/packages/workflow-transformer-async/Readme.md
@@ -8,6 +8,9 @@ npm install workflow-transformer-async
 
 Add the plugin to your `~/.workflow/config.js` file.
 
+**Note:** The `WorkflowTransformerAsync` plugin must be the first transformer
+in the list of `transformers` for the rest of the transformers to work properly.
+
 ```
 import WorkflowTranformerAsync from "workflow-transformer-async";
 

--- a/packages/workflow-transformer-async/cli.js
+++ b/packages/workflow-transformer-async/cli.js
@@ -1,0 +1,57 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+const { join } = require('path');
+const WorkflowResolverRelative = require('workflow-resolver-relative');
+const WorkflowResolverAbsolute = require('workflow-resolver-absolute');
+const WorkflowLoaderBabel = require('workflow-loader-babel');
+const WorkflowParserArguments = require('workflow-parser-arguments');
+const WorkflowTransformerApplyArgumentsToFields = require('workflow-transformer-apply-arguments-to-fields');
+const WorkflowTransformerAsync = require('workflow-transformer-async');
+const WorkflowLayout = require('workflow-layout');
+const WorkflowWm = require('workflow-wm-auto');
+
+const babelConfig = {
+  config: {
+    presets: [
+      'flow',
+      'react',
+      [
+        'env',
+        {
+          targets: {
+            node: 'current',
+          },
+        },
+      ],
+    ],
+    plugins: ['transform-object-rest-spread', 'transform-class-properties'],
+  },
+};
+
+const config = {
+  resolvers: [
+    new WorkflowResolverAbsolute(),
+    new WorkflowResolverRelative({ path: process.cwd() }),
+    new WorkflowResolverRelative({ path: join(__dirname, 'flows') }),
+  ],
+  loaders: [{ loader: new WorkflowLoaderBabel(babelConfig) }],
+  argumentParser: new WorkflowParserArguments(),
+  transformers: [new WorkflowTransformerAsync(), new WorkflowTransformerApplyArgumentsToFields()],
+  layout: new WorkflowLayout(),
+  wm: new WorkflowWm(),
+};
+
+const workflow = require('workflow-core').workflow(config);
+
+async function run() {
+  const path = process.argv[2];
+  const absolutePath = await workflow.resolve(path);
+  let flow = await workflow.load(absolutePath);
+  const args = {};
+  flow = await workflow.transform(flow.default, { args });
+  const screen = await workflow.screen();
+  const layout = await workflow.layout(flow, { screen });
+  await workflow.apply(layout);
+}
+
+run().catch(err => console.error(err));

--- a/packages/workflow-transformer-async/flows/Example.js
+++ b/packages/workflow-transformer-async/flows/Example.js
@@ -21,11 +21,12 @@ export default {
         },
         {
           type: 'async',
-          loader: async () => ({
+          cwd: __dirname,
+          cmd: 'pwd',
+          percent: 0.5,
+          loader: async props => ({
             ...Terminal,
-            cwd: __dirname,
-            cmd: 'pwd',
-            percent: 0.5,
+            ...props,
           }),
         },
       ],

--- a/packages/workflow-transformer-async/flows/Example.js
+++ b/packages/workflow-transformer-async/flows/Example.js
@@ -1,0 +1,34 @@
+/* eslint-env node */
+import { Terminal } from 'workflow-apps-defaults';
+
+export default {
+  name: 'workflow-example',
+  type: 'workspace',
+  children: [
+    {
+      type: 'layout',
+      layout: 'splith',
+      percent: 1.0,
+      children: [
+        {
+          type: 'async',
+          loader: async () => ({
+            ...Terminal,
+            cwd: __dirname,
+            cmd: 'pwd',
+            percent: 0.5,
+          }),
+        },
+        {
+          type: 'async',
+          loader: async () => ({
+            ...Terminal,
+            cwd: __dirname,
+            cmd: 'pwd',
+            percent: 0.5,
+          }),
+        },
+      ],
+    },
+  ],
+};

--- a/packages/workflow-transformer-async/flows/ReactExample.js
+++ b/packages/workflow-transformer-async/flows/ReactExample.js
@@ -1,0 +1,20 @@
+/* eslint-env node */
+import React from 'react';
+import render, { Workspace, requireComponent, createComponentRecursive } from 'workflow-react';
+import { Terminal } from 'workflow-apps-defaults';
+
+const TerminalAsync = createComponentRecursive({
+  type: 'async',
+  name: 'TerminalAsync',
+  loader: async () => Terminal,
+});
+const { SplitV } = requireComponent('workflow-layout-tiled');
+
+export default render(
+  <Workspace name={'workflow-apps-defaults'}>
+    <SplitV percent={1.0}>
+      <TerminalAsync percent={0.5} cwd={__dirname} cmd={'pwd'} />
+      <TerminalAsync percent={0.5} cwd={__dirname} cmd={'pwd'} />
+    </SplitV>
+  </Workspace>
+);

--- a/packages/workflow-transformer-async/flows/ReactExample.js
+++ b/packages/workflow-transformer-async/flows/ReactExample.js
@@ -1,20 +1,24 @@
 /* eslint-env node */
 import React from 'react';
-import render, { Workspace, requireComponent, createComponentRecursive } from 'workflow-react';
+import render, { Workspace, Async, requireComponent } from 'workflow-react';
 import { Terminal } from 'workflow-apps-defaults';
-
-const TerminalAsync = createComponentRecursive({
-  type: 'async',
-  name: 'TerminalAsync',
-  loader: async () => Terminal,
-});
 const { SplitV } = requireComponent('workflow-layout-tiled');
 
 export default render(
   <Workspace name={'workflow-apps-defaults'}>
     <SplitV percent={1.0}>
-      <TerminalAsync percent={0.5} cwd={__dirname} cmd={'pwd'} />
-      <TerminalAsync percent={0.5} cwd={__dirname} cmd={'pwd'} />
+      <Async
+        percent={0.5}
+        cwd={__dirname}
+        cmd={'pwd'}
+        loader={async props => ({ ...Terminal, ...props })}
+      />
+      <Async
+        percent={0.5}
+        cwd={__dirname}
+        cmd={'pwd'}
+        loader={async props => ({ ...Terminal, ...props })}
+      />
     </SplitV>
   </Workspace>
 );

--- a/packages/workflow-transformer-async/index.js
+++ b/packages/workflow-transformer-async/index.js
@@ -1,0 +1,12 @@
+/* eslint-env node */
+/* eslint-disable global-require */
+
+try {
+  module.exports = require('./dist');
+} catch (error) {
+  if (error.code === 'MODULE_NOT_FOUND') {
+    module.exports = require('./src/index');
+  } else {
+    throw error;
+  }
+}

--- a/packages/workflow-transformer-async/package.json
+++ b/packages/workflow-transformer-async/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-transformer-async",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.0",
   "description": "Workflow transformer to support async type",
   "license": "MIT",
   "main": "index.js",

--- a/packages/workflow-transformer-async/package.json
+++ b/packages/workflow-transformer-async/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "workflow-transformer-async",
+  "version": "0.0.0",
+  "description": "Workflow transformer to support async type",
+  "license": "MIT",
+  "main": "index.js",
+  "author": "Rolf Erik Lekang <me@rolflekang.com>",
+  "scripts": {
+    "example": "node cli.js Example.js"
+  },
+  "keywords": [
+    "workflow-wm",
+    "transformer",
+    "workflow"
+  ],
+  "files": [
+    "dist",
+    "index.js"
+  ]
+}

--- a/packages/workflow-transformer-async/package.json
+++ b/packages/workflow-transformer-async/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "author": "Rolf Erik Lekang <me@rolflekang.com>",
   "scripts": {
-    "example": "node cli.js Example.js"
+    "example": "node cli.js Example.js",
+    "react-example": "node cli.js ReactExample.js"
   },
   "keywords": [
     "workflow-wm",

--- a/packages/workflow-transformer-async/src/index.js
+++ b/packages/workflow-transformer-async/src/index.js
@@ -1,8 +1,9 @@
 export default class WorkflowTransformerAsync {
   async transformBefore(node) {
-    switch (node.type) {
+    const { type, loader, ...rest } = node;
+    switch (type) {
       case 'async':
-        return await node.loader();
+        return { ...rest, ...(await loader()) };
       default:
         return node;
     }

--- a/packages/workflow-transformer-async/src/index.js
+++ b/packages/workflow-transformer-async/src/index.js
@@ -3,7 +3,7 @@ export default class WorkflowTransformerAsync {
     const { type, loader, ...rest } = node;
     switch (type) {
       case 'async':
-        return { ...rest, ...(await loader()) };
+        return await loader(rest);
       default:
         return node;
     }

--- a/packages/workflow-transformer-async/src/index.js
+++ b/packages/workflow-transformer-async/src/index.js
@@ -1,0 +1,10 @@
+export default class WorkflowTransformerAsync {
+  async transformBefore(node) {
+    switch (node.type) {
+      case 'async':
+        return await node.loader();
+      default:
+        return node;
+    }
+  }
+}

--- a/packages/workflow-transformer-async/test/unit/index_tests.js
+++ b/packages/workflow-transformer-async/test/unit/index_tests.js
@@ -1,0 +1,31 @@
+import WorkflowTransformerAsync from '../../src';
+
+let transformer;
+beforeAll(() => {
+  transformer = new WorkflowTransformerAsync();
+});
+
+test('WorkflowTransformerAsync should transform to the value that loader resolves when type is "async"', async () => {
+  const open = () => {};
+
+  const transformed = await transformer.transformBefore({
+    type: 'async',
+    loader: async () => ({ type: 'app', name: 'Iterm', open }),
+    percent: 0.5,
+  });
+
+  expect(transformed).toEqual({
+    type: 'app',
+    name: 'Iterm',
+    open,
+    percent: 0.5,
+  });
+});
+
+test('WorkflowTransformerAsync should do nothing when type is not "async"', async () => {
+  const app = { type: 'app', name: 'Iterm', open: () => {} };
+
+  const transformed = await transformer.transformBefore(app);
+
+  expect(transformed).toEqual(app);
+});

--- a/packages/workflow-transformer-async/test/unit/index_tests.js
+++ b/packages/workflow-transformer-async/test/unit/index_tests.js
@@ -10,7 +10,7 @@ test('WorkflowTransformerAsync should transform to the value that loader resolve
 
   const transformed = await transformer.transformBefore({
     type: 'async',
-    loader: async () => ({ type: 'app', name: 'Iterm', open }),
+    loader: async props => ({ ...props, type: 'app', name: 'Iterm', open }),
     percent: 0.5,
   });
 


### PR DESCRIPTION
This enables `type: "async"` with a property loader that is an async function
used to load a workflow plugin like app or layout.

Relates to #132

### Todo

- [x] Add description on how to use it in readme