### PR TITLE
fix(workflow-app-textedit): Always do document.create

### DIFF
--- a/packages/workflow-app-textedit/src/index.js
+++ b/packages/workflow-app-textedit/src/index.js
@@ -12,9 +12,7 @@ const safari = {
       (file, position) => {
         const Textedit = Application('TextEdit');
 
-        if (Textedit.running()) {
-          Textedit.Document().make();
-        }
+        Textedit.Document().make();
 
         Textedit.activate();
 


### PR DESCRIPTION
In some scenarios when textedit is not running when running the command
it will be flakey whether the create call is called or not, thus, the
opening of things in textedit will be flakey.