### PR TITLE
feat(codemods): initial implementation of 1.x to 2.x codemod

### DIFF
--- a/packages/workflow-codemods/package.json
+++ b/packages/workflow-codemods/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "workflow-codemods",
+  "version": "2.0.0-rc1",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "jscodeshift": "^0.5.1"
+  }
+}

--- a/packages/workflow-codemods/src/named-exports.js
+++ b/packages/workflow-codemods/src/named-exports.js
@@ -1,0 +1,87 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+
+  const root = j(file.source);
+
+  // Rewrite workflow- imports to named
+  // Before: import render from "workflow-react";
+  // After: import {render} from "workflow-react";
+  // Before import WorkflowWmI3 from "workflow-wm-i3";
+  // After: import {WorkflowWmI3} form "workflow-wm-i3";
+  root.find(j.ImportDeclaration).forEach(decl => {
+    if (decl.value.source.value.startsWith('workflow-')) {
+      decl.value.specifiers = decl.value.specifiers.map(specifier => {
+        if (specifier.type === 'ImportDefaultSpecifier') {
+          return j.importSpecifier(j.identifier(specifier.local.name));
+        } else {
+          return specifier;
+        }
+      });
+    }
+  });
+
+  // Rewrite require('workflow-*') to named exports
+  root.find(j.CallExpression).forEach(expr => {
+    if (expr.value.callee.name === 'require') {
+      if (expr.value.arguments[0].value.startsWith('workflow-')) {
+        if (expr.parentPath.value.id.type === 'Identifier') {
+          const name = expr.parentPath.value.id.name;
+          expr.parentPath.value.id = j.objectPattern([createSimpleProp(j, name)]);
+        }
+      }
+    }
+  });
+
+  // Rewrite requireComponent to named exports
+  root.find(j.CallExpression).forEach(expr => {
+    if (expr.value.callee.name === 'requireComponent') {
+      if (expr.parentPath.value.id.type === 'Identifier') {
+        const name = expr.parentPath.value.id.name;
+        expr.parentPath.value.id = j.objectPattern([createSimpleProp(j, name)]);
+      }
+    }
+  });
+
+  // Rewirte flow file export
+  if (file.path.includes('flows')) {
+    root
+      .find(j.ExportDefaultDeclaration)
+      .replaceWith(decl =>
+        j.exportNamedDeclaration(
+          j.variableDeclaration('const', [
+            j.variableDeclarator(j.identifier('flow'), decl.value.declaration),
+          ])
+        )
+      );
+  }
+
+  if (file.path.endsWith('config.js')) {
+    // Rewrite config file export
+    root
+      .find(j.ExportDefaultDeclaration)
+      .replaceWith(decl =>
+        j.exportNamedDeclaration(
+          j.variableDeclaration('const', [
+            j.variableDeclarator(j.identifier('config'), decl.value.declaration),
+          ])
+        )
+      );
+
+    // Rewrite config file module.exports
+    root.find(j.AssignmentExpression).forEach(e => {
+      if (e.value.left.object.name === 'module' && e.value.left.property.name === 'exports') {
+        e.value.right = j.objectExpression([
+          j.property('init', j.identifier('config'), e.value.right),
+        ]);
+      }
+    });
+  }
+
+  return root.toSource();
+};
+
+function createSimpleProp(j, name) {
+  const prop = j.property('init', j.identifier(name), j.identifier(name));
+  prop.shorthand = true;
+  return prop;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6925,7 +6925,7 @@ jscodeshift@^0.4.0:
     temp "^0.8.1"
     write-file-atomic "^1.2.0"
 
-jscodeshift@^0.5.0:
+jscodeshift@^0.5.0, jscodeshift@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.5.1.tgz#4af6a721648be8638ae1464a190342da52960c33"
   dependencies:


### PR DESCRIPTION
Makes the following diff when running against a slightly modified version of the output from `npx create-workflow-home@1.0.0`

```diff
diff --git a/config.js b/config.js
index 9c14de0..59ef6cd 100644
--- a/config.js
+++ b/config.js
@@ -1,12 +1,26 @@
 /* eslint-env node */
 const { join } = require('path');
-const WorkflowResolverRelative = require('workflow-resolver-relative');
-const WorkflowResolverAbsolute = require('workflow-resolver-absolute');
-const WorkflowLoaderBabel = require('workflow-loader-babel');
-const WorkflowParserArguments = require('workflow-parser-arguments');
-const WorkflowTransformerApplyArgumentsToFields = require('workflow-transformer-apply-arguments-to-fields');
-const WorkflowLayout = require('workflow-layout');
-const WorkflowWm = require('workflow-wm-i3');
+const {
+  WorkflowResolverRelative
+} = require('workflow-resolver-relative');
+const {
+  WorkflowResolverAbsolute
+} = require('workflow-resolver-absolute');
+const {
+  WorkflowLoaderBabel
+} = require('workflow-loader-babel');
+const {
+  WorkflowParserArguments
+} = require('workflow-parser-arguments');
+const {
+  WorkflowTransformerApplyArgumentsToFields
+} = require('workflow-transformer-apply-arguments-to-fields');
+const {
+  WorkflowLayout
+} = require('workflow-layout');
+const {
+  WorkflowWm
+} = require('workflow-wm-i3');
 
 const config = {
   presets: [
@@ -25,14 +39,16 @@ const config = {
 };
 
 module.exports = {
-  resolvers: [
-    new WorkflowResolverAbsolute(),
-    new WorkflowResolverRelative({ path: process.cwd() }),
-    new WorkflowResolverRelative({ path: join(__dirname, 'flows') }),
-  ],
-  loaders: [{ loader: new WorkflowLoaderBabel({ config }) }],
-  argumentParser: new WorkflowParserArguments(),
-  transformers: [new WorkflowTransformerApplyArgumentsToFields()],
-  layout: new WorkflowLayout(),
-  wm: new WorkflowWm(),
+  config: {
+    resolvers: [
+      new WorkflowResolverAbsolute(),
+      new WorkflowResolverRelative({ path: process.cwd() }),
+      new WorkflowResolverRelative({ path: join(__dirname, 'flows') }),
+    ],
+    loaders: [{ loader: new WorkflowLoaderBabel({ config }) }],
+    argumentParser: new WorkflowParserArguments(),
+    transformers: [new WorkflowTransformerApplyArgumentsToFields()],
+    layout: new WorkflowLayout(),
+    wm: new WorkflowWm(),
+  }
 };
diff --git a/flows/Example.js b/flows/Example.js
index b66a761..61276dd 100644
--- a/flows/Example.js
+++ b/flows/Example.js
@@ -1,9 +1,10 @@
 /* eslint-env node */
 import { Browser, TextEditor } from 'workflow-apps-defaults';
 
-export default {
+export const flow = {
   name: 'workflow-example',
   type: 'workspace',
+
   children: [
     {
       type: 'layout',
@@ -18,5 +19,5 @@ export default {
         { ...TextEditor, file: __filename, percent: 0.5 },
       ],
     },
-  ],
+  ]
 };
diff --git a/flows/ReactExample.js b/flows/ReactExample.js
index 3cbf1cf..368f17b 100644
--- a/flows/ReactExample.js
+++ b/flows/ReactExample.js
@@ -1,19 +1,20 @@
 /* eslint-env node */
 
 import React from 'react';
-import render, { Workspace, requireComponent } from 'workflow-react';
+import { render, Workspace, requireComponent } from 'workflow-react';
 
 const { SplitH, SplitV } = requireComponent('workflow-layout-tiled');
-const { TextEditor, Browser, Terminal } = requireComponent('workflow-apps-defaults');
+const { Browser, Terminal } = requireComponent('workflow-apps-defaults');
+const {
+  Emacs
+} = requireComponent('workflow-app-emacs');
 
-export default render(
-  <Workspace name={'workflow-react-example'}>
-    <SplitV percent={1.0}>
-      <SplitH percent={0.8}>
-        <TextEditor percent={0.5} file={__filename} />
-        <Browser percent={0.5} url={'https://github.com/havardh/workflow'} />
-      </SplitH>
-      <Terminal percent={0.2} cwd={__dirname} />
-    </SplitV>
-  </Workspace>
-);
+export const flow = render(<Workspace name={'workflow-react-example'}>
+  <SplitV percent={1.0}>
+    <SplitH percent={0.8}>
+      <Emacs percent={0.5} file={__filename} />
+      <Browser percent={0.5} url={'https://github.com/havardh/workflow'} />
+    </SplitH>
+    <Terminal percent={0.2} cwd={__dirname} />
+  </SplitV>
+</Workspace>);
```