### PR TITLE
fix(workflow-cmd): replace npm-check-updates dependency with npm

### DIFF
--- a/packages/workflow-cmd/package.json
+++ b/packages/workflow-cmd/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "cross-spawn": "^6.0.5",
     "execa": "^1.0.0",
-    "npm-check-updates": "^2.14.2",
     "prompt": "^1.0.0",
     "read-pkg-up": "^4.0.0",
     "shelljs": "^0.8.2",

--- a/packages/workflow-cmd/src/commands/update.js
+++ b/packages/workflow-cmd/src/commands/update.js
@@ -1,12 +1,10 @@
 /* eslint-env node */
 /* eslint-disable no-console */
 import execa from 'execa';
-import ncu from 'npm-check-updates';
 import { join } from 'path';
 import fs from 'fs';
 import prompt from 'prompt';
 import { promisify } from 'util';
-import readPkgUp from 'read-pkg-up';
 
 import { baseFolder } from 'shared/env';
 import { which } from 'shared/shell';
@@ -105,12 +103,12 @@ async function updateWorkflowHome(args) {
         },
       },
     });
-  }
 
-  if (update === 'n' || update === 'N') {
-    console.log();
-    console.log('Exit without making changes to', baseFolder);
-    process.exit(0);
+    if (update === 'n' || update === 'N') {
+      console.log();
+      console.log('Exit without making changes to', baseFolder);
+      process.exit(0);
+    }
   }
 
   let stdout;
@@ -140,10 +138,6 @@ async function updateWorkflowHome(args) {
     console.error(e);
     process.exit(1);
   }
-}
-
-function hasUpdates(code) {
-  return code !== 0;
 }
 
 function parsePackages(outdatedOutput) {


### PR DESCRIPTION
The ncu dependency depends on `npm`, this causes a lot of issues in the build.
This change removes this dependency in favor of using the `npm` command directly
with `npm outdated`, `npm install`, and `npm update`.