### PR TITLE
fix(workflow): wait on createWorkflowHome before running npm install

### DIFF
--- a/packages/workflow/src/cli.js
+++ b/packages/workflow/src/cli.js
@@ -41,7 +41,7 @@ async function initWorkflowHome(path) {
   if (
     await promptYesNo('Would you like to initialize a workflow-home directory at: ' + resolve(path))
   ) {
-    createWorkflowHome(path);
+    await createWorkflowHome(path);
 
     console.log();
     console.log('Running `npm install`');


### PR DESCRIPTION
Wait for the workflow-home folder to be generated before trying to install the
dependencies in that folder.